### PR TITLE
Confirmation modal when overriding assets with already existing name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ test-results/
 .scannerwork
 
 # Localization Resources
-/server/locales/**/*.yml
+#/server/locales/**/*.yml

--- a/server/locales/en.yml
+++ b/server/locales/en.yml
@@ -1,0 +1,5 @@
+editor:
+  assets.overrideAssets: 'Override Assets'
+  assets.overrideAssetsConfirm: 'Conflicting file names, are you sure you want to override '
+  assets.overrideAssetsWarn: 'This action cannot be undone!'
+  assets.actions.override: 'Override'


### PR DESCRIPTION
See Requarks#3176, this PR cherry-picks the commits from the Requarks#3176 PR on top of the last release deployed at Alice&Bob (`2.5.170`), to our custom `2.5.170+ab` branch.

This PR replaces #1 for the reasons explained in Requarks#3176.

Demo:

![demo](https://user-images.githubusercontent.com/38159029/110023956-0f160100-7d2e-11eb-8e95-db1ab0760fc8.png)
